### PR TITLE
Add Qt base translation to our own

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           git clone https://github.com/PrismLauncher/PrismLauncher.git src
 
+          export LCONVERT_BIN="/usr/lib/qt6/bin/lconvert"
           export LUPDATE_BIN="/usr/lib/qt6/bin/lupdate"
 
           ./update.sh

--- a/update.sh
+++ b/update.sh
@@ -5,19 +5,21 @@ set -e
 ROOT="$(pwd)"
 SRC=${ROOT}/src
 
+LCONVERT_BIN=${LCONVERT_BIN:-lconvert}
 LUPDATE_BIN=${LUPDATE_BIN:-lupdate}
 
 ###############################################################################
 
+curl https://l10n-files.qt.io/l10n-files/qt-old65/qtbase_untranslated.ts --output ./qtbase_untranslated.ts
 readarray -d '' SOURCE_FILES < <(find "$SRC" -regex '.*\.\(h\|cpp\|ui\)' -type f -print0)
 
 update_file() {
     ts_file="$1"
 
-    echo "Updating $ts_file..."
-
     # Update .ts
     $LUPDATE_BIN "${SOURCE_FILES[@]}" -locations "absolute" -ts "$ts_file"
+    $LCONVERT_BIN -i "$ts_file" ./qtbase_untranslated.ts -o "$ts_file"
+    $LUPDATE_BIN -ts "$ts_file" -noobsolete
 }
 
 cd "$ROOT"
@@ -31,3 +33,5 @@ else
 
     update_file .template.ts
 fi
+
+rm ./qtbase_untranslated.ts


### PR DESCRIPTION
I don't know if this works as intended: it builds but locally the .template file is emptied regardless if I run with or without my change.
Regarding the Licence issues this was downloaded from the qt website(https://l10n-files.qt.io/l10n-files/) also the git repo licenses https://code.qt.io/cgit/qt/qttranslations.git/tree/LICENSES?h=6.5
Theoretically, we are not using any of the translations provided by them, just the template to add to our own.
this should fix https://github.com/PrismLauncher/PrismLauncher/issues/2833 and any other translation issue with the qt in our code.

