### PR TITLE
Enable translations of stable version

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,7 +51,13 @@ jobs:
       - name: Update translations
         run: |
           git clone https://github.com/PrismLauncher/PrismLauncher.git src
-
+          
+          # copy repo and checkout latest tag
+          cp -r src src_stable
+          cd src_stable
+          git checkout -b stable $(git describe --tags $(git rev-list --tags --max-count=1))
+          cd ..
+          
           export LUPDATE_BIN="/usr/lib/qt6/bin/lupdate"
 
           ./update.sh

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -51,13 +51,9 @@ jobs:
       - name: Update translations
         run: |
           git clone https://github.com/PrismLauncher/PrismLauncher.git src
-          
-          # copy repo and checkout latest tag
-          cp -r src src_stable
-          cd src_stable
-          git checkout -b stable $(git describe --tags $(git rev-list --tags --max-count=1))
-          cd ..
-          
+          # create worktree for latest stable tag
+          git -C src worktree add -b stable ../src_stable $(git rev-list --tags --max-count=1)
+
           export LUPDATE_BIN="/usr/lib/qt6/bin/lupdate"
 
           ./update.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /src
+/src_stable
 /build

--- a/update.sh
+++ b/update.sh
@@ -4,12 +4,13 @@ set -e
 
 ROOT="$(pwd)"
 SRC=${ROOT}/src
+SRC_STABLE=${ROOT}/src_stable
 
 LUPDATE_BIN=${LUPDATE_BIN:-lupdate}
 
 ###############################################################################
 
-readarray -d '' SOURCE_FILES < <(find "$SRC" -regex '.*\.\(h\|cpp\|ui\)' -type f -print0)
+readarray -d '' SOURCE_FILES < <(find "$SRC" "$SRC_STABLE" -regex '.*\.\(h\|cpp\|ui\)' -type f -print0)
 
 update_file() {
     ts_file="$1"
@@ -18,6 +19,9 @@ update_file() {
 
     # Update .ts
     $LUPDATE_BIN "${SOURCE_FILES[@]}" -locations "absolute" -ts "$ts_file"
+
+    # Remove all locations for stable
+    sed -i "/<location filename=\"src_stable/d" "$ts_file"
 }
 
 cd "$ROOT"


### PR DESCRIPTION
Fix #20.

The way it works it that the source code for both the stable and the latest version is paased to lupdate command together, and the `type="vanished"` in the stable translations are removed and these translations are enabled.
(Translations that are coverd by the latest version will only have the location tag added to the existing translation.)

All `location` tags in stable translations will be removed, as the just cause confusion. (because when opened from Weblate, the code in the "develop" branch is always referenced)

I have aready confirmed this works by [act](https://github.com/nektos/act).
If you have any problems with this, please let me know.