### PR TITLE
fix: exclude pre-release tags from latest stable tag

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           git clone https://github.com/PrismLauncher/PrismLauncher.git src
           # create worktree for latest stable tag
-          git -C src worktree add -b stable ../src_stable $(git -C src rev-list --tags --max-count=1)
+          git -C src worktree add -b stable ../src_stable "refs/tags/$(git -C src tag -l --sort=-v:refname | grep -v -m1 "pre")"
 
           nix develop . -c ./update.sh
 


### PR DESCRIPTION
This change excludes tags containing "pre" when getting the latest stable tag.
This is because 10.0.0 was pre-released, and its 10.0.0-pre1 tag was being used as the latest stable version.